### PR TITLE
Add GitHub workflow to build and publish to surge.sh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: npm install
@@ -24,8 +24,11 @@ jobs:
       - name: Build the app
         run: npm run build
 
+      - name: Install Surge
+        run: npm install --global surge
+
       - name: Deploy to Surge
-        run: npx surge ./dist gym-tracker.surge.sh
+        run: surge dist
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to Surge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the app
+        run: npm run build
+
+      - name: Deploy to Surge
+        run: surge ./dist gym-tracker.surge.sh
+        env:
+          SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Ensure surge is installed
+        run: npm install --global surge
+
       - name: Build the app
         run: npm run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,14 +21,11 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Ensure surge is installed
-        run: npm install --global surge
-
       - name: Build the app
         run: npm run build
 
       - name: Deploy to Surge
-        run: surge ./dist gym-tracker.surge.sh
+        run: npx surge ./dist gym-tracker.surge.sh
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+gym-tracker.surge.sh


### PR DESCRIPTION
Add GitHub Actions workflow to build and deploy the app to Surge on push to the main branch.

* **Add CNAME file:**
  - Add `public/CNAME` file with the content `gym-tracker.surge.sh`.

* **Add GitHub Actions workflow:**
  - Add `.github/workflows/deploy.yml` file.
  - Use `actions/checkout@v2` to check out the repository.
  - Use `actions/setup-node@v2` to set up Node.js and specify the node version from `.nvmrc`.
  - Run `npm install` to install dependencies.
  - Run `npm run build` to build the app.
  - Use `surge` to publish the app to `gym-tracker.surge.sh`.
  - Authenticate to Surge using GitHub secrets for `SURGE_LOGIN` and `SURGE_TOKEN`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/receter/gym-tracker?shareId=cd4e079c-d50e-49b5-b3ea-4da2c778f9fc).